### PR TITLE
Fix broken dbaas e2e test on OpenShift 4.10

### DIFF
--- a/pkg/tests/dbaas_operator_tests.go
+++ b/pkg/tests/dbaas_operator_tests.go
@@ -22,7 +22,7 @@ var _ = ginkgo.Describe("DBaaS Operator Tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Make sure the CRD exists
-		_, err = apiextensions.ApiextensionsV1beta1().CustomResourceDefinitions().Get("dbaasplatforms.dbaas.redhat.com", v1.GetOptions{})
+		_, err = apiextensions.ApiextensionsV1().CustomResourceDefinitions().Get("dbaasplatforms.dbaas.redhat.com", v1.GetOptions{})
 
 		if err != nil {
 			metadata.Instance.FoundCRD = false


### PR DESCRIPTION
Beta API no longer works on recent OpenShift versions

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>