### PR TITLE
Fix E2E test failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/RHEcosystemAppEng/dbaas-operator v0.1.5-0.20220329142537-6708678c607a
 	github.com/chromedp/cdproto v0.0.0-20220530001853-c0f376d894d1
 	github.com/chromedp/chromedp v0.8.2
-	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
@@ -42,7 +41,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -59,7 +57,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/component-base v0.22.1 // indirect

--- a/pkg/tests/dbaas_operator_tests.go
+++ b/pkg/tests/dbaas_operator_tests.go
@@ -4,12 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
-
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
@@ -25,7 +19,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"os"
+	"path/filepath"
+	"regexp"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
 )
 
 var _ = Describe("Rhoda e2e Test", func() {

--- a/pkg/tests/dbaas_operator_tests.go
+++ b/pkg/tests/dbaas_operator_tests.go
@@ -3,8 +3,13 @@ package tests
 import (
 	"context"
 	"errors"
-	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
 	dbaasv1alpha1 "github.com/RHEcosystemAppEng/dbaas-operator/api/v1alpha1"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
@@ -20,12 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"os"
-	"path/filepath"
-	"regexp"
 	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 )
 
 var _ = Describe("Rhoda e2e Test", func() {
@@ -54,6 +54,18 @@ var _ = Describe("Rhoda e2e Test", func() {
 			//loop through providers
 			for i := range providers {
 				provider := providers[i]
+				providerType := string(provider.SecretData["providerType"])
+				BeforeEach(func() {
+					By(fmt.Sprintf("Checking if provider operator is ready: %s", provider.ProviderName))
+					Eventually(func() bool {
+						if err := client.Get(context.Background(), k8sClient.ObjectKey{
+							Name: providerType,
+						}, &dbaasv1alpha1.DBaaSProvider{}); err != nil {
+							return false
+						}
+						return true
+					}, time.Second*120, time.Second).Should(BeTrue())
+				})
 				It("Should pass when secret and provider created and connection status is checked for "+provider.ProviderName, func() {
 					DeferCleanup(func() {
 						fmt.Println("DeferCleanup Started")
@@ -121,7 +133,7 @@ var _ = Describe("Rhoda e2e Test", func() {
 						Spec: dbaasv1alpha1.DBaaSOperatorInventorySpec{
 							ProviderRef: dbaasv1alpha1.NamespacedName{
 								Namespace: namespace,
-								Name:      string(provider.SecretData["providerType"]),
+								Name:      providerType,
 							},
 							DBaaSInventorySpec: dbaasv1alpha1.DBaaSInventorySpec{
 								CredentialsRef: &dbaasv1alpha1.NamespacedName{
@@ -367,17 +379,14 @@ func getProvidersData(providerNames []string, ciSecretData map[string][]byte) []
 func getConfig() (config *rest.Config, err error) {
 	fmt.Println("Running getConfig")
 	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" {
-		var kubeconfig *string
-		if home := homedir.HomeDir(); home != "" {
-			kubeconfig = flag.String("kconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		var kubeconfig string
+		if kconfig := os.Getenv("KUBECONFIG"); len(kconfig) > 0 {
+			kubeconfig = kconfig
 		} else {
-			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+			kubeconfig = filepath.Join(homedir.HomeDir(), ".kube", "config")
 		}
-		flag.Parse()
-
 		// use the current context in kubeconfig
-		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
-
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	} else {
 		config, err = rest.InClusterConfig()
 	}


### PR DESCRIPTION
OSD E2E prow job failed:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-stage-aws-addon-dbaas-operator/1541753408988385280
Error message:
admission webhook "vdbaasinventory.kb.io" denied the request: DBaaSProvider.dbaas.redhat.com "XXXXXXXXXXXXXXXXXXXXXXXXXXX" not found
  occurred[0m
  [38;5;9mIn [1m[It][0m[38;5;9m at: [1m/go/src/github.com/RHEcosystemAppEng/dbaas-e2e-test-harness/pkg/tests/dbaas_operator_tests.go:135[0m]

This PR is to check if the provider operator has finished its registration with the DBaaS operator by creating its dbaasprovider CR.

Tested done on the lab https://api.rhoda-49-lab.5xr9.p1.openshiftapps.com:6443
